### PR TITLE
json_api_many && json_api_one have set_relationship as false by default.

### DIFF
--- a/lib/jaf/routes.rb
+++ b/lib/jaf/routes.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-def json_api_many(name, only: %w[index show create update destroy], except: [], set_relationship: true)
+def json_api_many(name, only: %w[index show create update destroy], except: [], set_relationship: false)
   resources name, only: only - except
   return unless set_relationship
 
@@ -12,7 +12,7 @@ def json_api_many(name, only: %w[index show create update destroy], except: [], 
   end
 end
 
-def json_api_one(name, only: %w[show update destroy], except: [], set_relationship: true)
+def json_api_one(name, only: %w[show update destroy], except: [], set_relationship: false)
   resource name, only: only - except
   return unless set_relationship
 

--- a/spec/dummy/config/routes.rb
+++ b/spec/dummy/config/routes.rb
@@ -1,16 +1,16 @@
 Rails.application.routes.draw do
   json_api_resources :users do
-    json_api_many :lists
+    json_api_many :lists, set_relationship: true
   end
 
   json_api_resources :lists do
-    json_api_many :todos
-    json_api_one :user
+    json_api_many :todos, set_relationship: true
+    json_api_one :user, set_relationship: true
 
     get :permissions, to: 'permissions#index'
   end
 
   json_api_resources :todos do
-    json_api_one :list
+    json_api_one :list, set_relationship: true
   end
 end


### PR DESCRIPTION
Relationship routes are not created by default anymore.